### PR TITLE
Revert "Fix: ModuleNotFoundError: No module named 'cgi'"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-alpine3.19
+FROM python:3-alpine3.19
 LABEL maintainer="Mohammed Moosa Sharieff"
 
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Reverts moosasharieff/Ticketing_API#4 as I later found that this error was cause due to using drf-spectacular package for Automated API Documentation. 